### PR TITLE
Windows

### DIFF
--- a/.github/workflows/LuaWatcom.yml
+++ b/.github/workflows/LuaWatcom.yml
@@ -64,11 +64,11 @@ jobs:
 
     - name: Create Zip Binaries
       run: |
-          zip -j9 "dist/Lua DOS Bin.zip" dist/bin/*.exe example.lua
+          zip -j9 --DOS-names "dist/Lua DOS Bin.zip" dist/bin/*.exe example.lua
 
     - name: Zip Disk Images
       run: |
-          zip -j9 "dist/Lua DOS Ima.zip" dist/*.ima
+          zip -j9 --DOS-names "dist/Lua DOS Ima.zip" dist/*.ima
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/LuaWatcom.yml
+++ b/.github/workflows/LuaWatcom.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Create Zip Binaries
       run: |
-          zip -j9 "dist/Lua DOS Bin.zip" dist/bin/*.exe
+          zip -j9 "dist/Lua DOS Bin.zip" dist/bin/*.exe example.lua
 
     - name: Zip Disk Images
       run: |

--- a/.github/workflows/LuaWatcom.yml
+++ b/.github/workflows/LuaWatcom.yml
@@ -3,8 +3,8 @@ name: Lua for Watcom
 on: push
 
 jobs:
-  DOS:
-    name: Lua for DOS
+  Watcom:
+    name: Lua for Watcom
     runs-on: ubuntu-latest
 
     steps:
@@ -25,6 +25,11 @@ jobs:
       run: |
         export INCLUDE=$WATCOM/h
         wmake -f wm_dos4g.mak
+
+    - name: Build Lua for WinNT
+      run: |
+        export INCLUDE=$WATCOM/h/nt:$WATCOM/h
+        wmake -f wm_winnt.mak
 
     - name: UPX Binary Compression
       uses: crazy-max/ghaction-upx@v3
@@ -79,7 +84,7 @@ jobs:
           mformat -C -i dist/Lua3HD18.ima -v LUA -f 1440
           mcopy -i dist/Lua3HD18.ima dist/bin/*.exe example.lua ::
 
-    - name: Zip Binaries
+    - name: Create Zip Binaries
       run: |
           zip -j9 "dist/Lua DOS Bin.zip" dist/bin/*.exe
 

--- a/.github/workflows/LuaWatcom.yml
+++ b/.github/workflows/LuaWatcom.yml
@@ -43,36 +43,14 @@ jobs:
       run: |
           cp $WATCOM/binw/dos4gw.exe dist/bin/
 
-    - name: Install Post Build Tools (Dos2unix, GNU Mtools, Zip)
+    - name: Install Post Build Packaging Tools
       run: |
           sudo apt-get update
           sudo apt-get install -y dos2unix mtools zip
 
-    - name: Create Example Lua Script for Diskette Images
+    - name: Ensure Lua Scripts Have CR/LF Line Endings
       run: |
-          echo "-- This is a single line comment" > example.lua
-          echo "-- Run this script with 'LUA16.EXE EXAMPLE.LUA'" >> example.lua
-          echo "" >> example.lua
-          echo "-- Get hour of the day, convert it from string to number" >> example.lua
-          echo "hour = tonumber(os.date('%H'))" >> example.lua
-          echo "" >> example.lua
-          echo "-- Set the string 'timeOfDay' depending on the hour" >> example.lua
-          echo "if hour < 4 or hour > 20 then timeOfDay = 'night'" >> example.lua
-          echo "elseif hour < 9 then          timeOfDay = 'morning'" >> example.lua
-          echo "elseif hour > 16 then         timeOfDay = 'evening'" >> example.lua
-          echo "else                          timeOfDay = 'day'" >> example.lua
-          echo "end" >> example.lua
-          echo "" >> example.lua
-          echo "-- Concatenate timeOfDay & Lua version to as part of a greeting" >> example.lua
-          echo "print('Good ' .. timeOfDay .. ' from ' .. _VERSION .. '.')" >> example.lua
-          echo "" >> example.lua
-          echo "os.exit() -- Exit script. Will also exit a interactive shell" >> example.lua
-          echo "" >> example.lua
-          echo "--[[ This is a multi-line comment" >> example.lua
-          echo "     For full Lua language documentation" >> example.lua
-          echo "     visit https://www.lua.org/docs.html" >> example.lua
-          echo "--]]" >> example.lua
-          unix2dos example.lua
+          unix2dos *.lua
 
     - name: Create 160k Floppy Diskette Image
       run: |

--- a/example.lua
+++ b/example.lua
@@ -1,0 +1,23 @@
+#!/usr/bin/env lua
+-- This is a single line comment, the line above is a shebang for UNIX systems
+
+--[[ This is a multi-line comment. To run the script, pass it to the lua binary
+ as an argument (`LUA16.EXE EXAMPLE.LUA` on 16-bit DOS for example).
+ For full Lua language documentation visit https://www.lua.org/docs.html
+--]]
+
+hour = tonumber(os.date('%H')) -- Get the hour of day on the computers clock
+if hour < 4 or hour > 20 then  -- Convert hour into fuzzy time of day
+    timeOfDay = 'night'
+elseif hour < 9 then
+    timeOfDay = 'morning'
+elseif hour > 16 then
+    timeOfDay = 'evening'
+else
+    timeOfDay = 'day'
+end
+
+print('Good ' .. timeOfDay .. ' from ' .. _VERSION .. '.') -- Print a greeting
+io.read() -- Wait for Enter to be pressed
+print('Have a good ' .. timeOfDay .. '.') -- This message will
+os.exit() -- Exit script. Will also exit a interactive shell

--- a/wm_winnt.mak
+++ b/wm_winnt.mak
@@ -1,0 +1,75 @@
+# Watcom Makefile for building Lua 5.4.6
+# This is the DOS 4G flat model version
+# There are no configurable parts to this file
+# Run with `wmake -f wm_winnt.mak`
+
+objs =  $(OBJDIR)lapi.obj      $(OBJDIR)lctype.obj    &
+        $(OBJDIR)lfunc.obj     $(OBJDIR)lmathlib.obj  &
+        $(OBJDIR)loslib.obj    $(OBJDIR)ltable.obj    &
+        $(OBJDIR)lundump.obj   $(OBJDIR)lauxlib.obj   &
+        $(OBJDIR)ldblib.obj    $(OBJDIR)lgc.obj       &
+        $(OBJDIR)lmem.obj      $(OBJDIR)lparser.obj   &
+        $(OBJDIR)ltablib.obj   $(OBJDIR)lutf8lib.obj  &
+        $(OBJDIR)lbaselib.obj  $(OBJDIR)ldebug.obj    &
+        $(OBJDIR)linit.obj     $(OBJDIR)loadlib.obj   &
+        $(OBJDIR)lstate.obj    $(OBJDIR)ltm.obj       &
+        $(OBJDIR)lvm.obj       $(OBJDIR)lcode.obj     &
+        $(OBJDIR)ldo.obj       $(OBJDIR)liolib.obj    &
+        $(OBJDIR)lobject.obj   $(OBJDIR)lstring.obj   &
+        $(OBJDIR)lzio.obj      $(OBJDIR)lcorolib.obj  &
+        $(OBJDIR)ldump.obj     $(OBJDIR)llex.obj      &
+        $(OBJDIR)lopcodes.obj  $(OBJDIR)lstrlib.obj
+
+lua_obj = $(OBJDIR)lua.obj
+luac_obj = $(OBJDIR)luac.obj
+
+CC = *wcc386
+
+CFLAGS = -q -bt=nt -bc -3 -d0 -osr -zc
+LFLAGS = SYS nt OPT st=8192
+
+!ifdef __UNIX__
+BINDIR = dist/bin/
+OBJDIR = obj/winnt/
+SRCDIR = lua/
+!else
+BINDIR = dist\bin\ #
+OBJDIR = obj\winnt\ #
+SRCDIR = lua\ #
+!endif
+
+$(BINDIR)luant.exe: $(OBJDIR) $(BINDIR) $(objs) $(lua_obj)
+    *wlink NAME $@ $(LFLAGS) FILE {$(objs) $(lua_obj)}
+
+$(BINDIR)luacnt.exe: $(BINDIR) $(OBJDIR) $(objs) $(luac_obj)
+    *wlink NAME $@ $(LFLAGS) FILE {$(objs) $(luac_obj)}
+
+{$(SRCDIR)}.c{$(OBJDIR)}.obj:
+    $(CC) $(CFLAGS) -fo=$@ $<
+
+clean: .SYMBOLIC
+!ifdef __UNIX__
+    @!if [ -e $(OBJDIR) ]; then rm -R $(OBJDIR); fi
+    @!if [ -e $(BINDIR)luant.exe ]; then rm $(BINDIR)luant.exe; fi
+    @!if [ -e $(BINDIR)luacnt.exe ]; then rm $(BINDIR)luacnt.exe; fi
+!else
+    !ifdef __NT__
+         @!if exist $(OBJDIR) rd /S /Q $(OBJDIR)
+    !else
+         @!if exist $(OBJDIR) deltree /Y $(OBJDIR)
+    !endif
+    @!if exist $(BINDIR)luant.exe del $(BINDIR)luant.exe
+    @!if exist $(BINDIR)luacnt.exe del $(BINDIR)luacnt.exe
+!endif
+
+dist:
+    mkdir dist
+
+obj:
+    mkdir obj
+
+$(BINDIR): dist
+    mkdir $(BINDIR)
+
+$(OBJDIR): obj
+    mkdir $(OBJDIR)


### PR DESCRIPTION
Added `luant.exe` for running Lua on Windows. Despite the name "NT", this binary will run on all Windows 95 or later operating systems with a i386 or later processor.

Additional changes:
- Added a `io.read()` to `example.lua` so the script doesn't automatically close on graphical shells
- Added `example.lua` to the binary zip
- Create zips with DOS headers for better extraction compatibility on legacy systems