### PR TITLE
OS/2

### DIFF
--- a/.github/workflows/LuaWatcom.yml
+++ b/.github/workflows/LuaWatcom.yml
@@ -21,15 +21,25 @@ jobs:
         export INCLUDE=$WATCOM/h
         wmake -f wm_dos16.mak
 
-    - name: Build Lua for DOS4GW
+    - name: Build Lua for DOS4GW 32-bit Extender
       run: |
         export INCLUDE=$WATCOM/h
         wmake -f wm_dos4g.mak
 
-    - name: Build Lua for WinNT
+    - name: Build Lua for Windows 95
       run: |
         export INCLUDE=$WATCOM/h/nt:$WATCOM/h
         wmake -f wm_winnt.mak
+
+    - name: Build Lua for OS/2 16-bit
+      run: |
+        export INCLUDE=$WATCOM/h/os2:$WATCOM/h
+        wmake -f wm_os216.mak
+
+    - name: Build Lua for OS/2 32-bit
+      run: |
+        export INCLUDE=$WATCOM/h/os2:$WATCOM/h
+        wmake -f wm_os232.mak
 
     - name: UPX Binary Compression
       uses: crazy-max/ghaction-upx@v3

--- a/.github/workflows/LuaWatcom.yml
+++ b/.github/workflows/LuaWatcom.yml
@@ -47,7 +47,9 @@ jobs:
         version: latest
         args: -9 --8086
         files: |
-          dist/bin/*.exe
+          dist/bin/lua16.exe
+          dist/bin/lua4g.exe
+          dist/bin/luant.exe
 
     - name: Copy DOS4GW Binary
       run: |

--- a/README.md
+++ b/README.md
@@ -28,24 +28,32 @@ and **Instruction Set Architecture** (ISA) it is intended for.
 | Binary Name   | Native OS       | Native ISA |
 |---------------|-----------------|------------|
 | **LUA16.EXE** | Real mode DOS   | 8086       |
+| **LUA21.EXE** | OS/2 1.2        | 80286      |
+| **LUA22.EXE** | OS/2 2.0        | 80386      |
 | **LUA4G.EXE** | DOS4GW extender | 80386      |
 | **LUANT.EXE** | Windows 95      | 80386      |
 
 ### Binary Compatibility Matrix
 
-Some Operating Systems can run binaries intended for another out of the box. 
-Do keep in mind, however, that in most of these cases the Operating System is newer and has higher minimum requirements.
+Some OSes can run binaries intended for another out of the box. 
+Do keep in mind, however, that in most of these cases 
+the OS is newer and has higher minimum requirements.
 
-| Operating System                            | Minimum CPU ISA            | LUA16.EXE | LUA4G.EXE | LUANT.EXE |
-|---------------------------------------------|----------------------------|-----------|-----------|-----------|
-| DOS 2.x - 4.x<br/>Windows 1.x - Windows 3.x | 8086                       | Yes       | No        | No        |
-| DOS 5.x - 7.x                               | 8086<br>80386SX            | Yes       | No<br>Yes | No        |
-| Windows 95                                  | 80386SX                    | Yes       | Yes       | Yes       |
-| Windows 98                                  | 80486SX+80487SX<br>80486DX | Yes       | Yes       | Yes       |
-| Windows 2000 - ME                           | 80586                      | No        | No        | Yes       |
-| Windows XP                                  | 80586<br/>x86_64           | No        | No        | Yes       |
-| Windows Vista - 10                          | 80686<br/>x86_64           | No        | No        | Yes       |
-| Windows 11                                  | x86_64                     | No        | No        | Yes       |
+| Operating System                    | Minimum OS ISA(s)           | LUA16.EXE | LUA21.EXE | LUA22.EXE | LUA4G.EXE | LUANT.EXE |
+|-------------------------------------|-----------------------------|-----------|-----------|-----------|-----------|-----------|
+| DOS 2.x - 4.x<br/>Windows 1.x - 3.x | 8086                        | Yes       | No        | No        | No        | No        |
+| DOS 5.x - 7.x                       | 8086<br>80386SX             | Yes       | No        | No        | No<br>Yes | No        |
+| OS2 1.0 - 1.1                       | 80286                       | Yes       | No        | No        | No        | No        |
+| OS2 1.2 - 1.3                       | 80286                       | Yes       | Yes       | No        | No        | No        |
+| OS2 2.x                             | 80386SX                     | Yes       | Yes       | Yes       | No        | No        |
+| OS2 3.x                             | 80386SX                     | Yes       | Yes       | Yes       | Yes       | No        |
+| OS2 4.x                             | 80486SX                     | Yes       | Yes       | Yes       | Yes       | No        |
+| Windows 95                          | 80386SX                     | Yes       | No        | No        | Yes       | Yes       |
+| Windows 98                          | 80486DX<br/>80486SX+80487SX | Yes       | No        | No        | Yes       | Yes       |
+| Windows 2000 - ME                   | 80586                       | No        | No        | No        | No        | Yes       |
+| Windows XP                          | 80586<br/>x86_64            | No        | No        | No        | No        | Yes       |
+| Windows Vista - 10                  | 80686<br/>x86_64            | No        | No        | No        | No        | Yes       |
+| Windows 11                          | x86_64                      | No        | No        | No        | No        | Yes       |
 
 ## Build Requirements
 To build Lua with Open Watcom you will need the following:
@@ -80,7 +88,9 @@ To build Lua with Open Watcom you will need the following:
    |-------------------------|----------------------|-------------|--------------------|
    | `wmake -f wm_dos16.mak` | `dist/bin/lua16.exe` | PC-DOS 2.0+ | 8086/8088 or later |
    | `wmake -f wm_dos4g.mak` | `dist/bin/lua4g.exe` | MS-DOS 5.0+ | 80386 or later     |
-   | `wmake -f wm_dosnt.mak` | `dist/bin/luant.exe` | Windows 95+ | 80386 or later     |
+   | `wmake -f wm_os216.mak` | `dist/bin/lua21.exe` | OS/2 1.2    | 80286 or later     |
+   | `wmake -f wm_os232.mak` | `dist/bin/lua22.exe` | OS/2 2.0    | 80386 or later     |
+   | `wmake -f wm_winnt.mak` | `dist/bin/luant.exe` | Windows 95+ | 80386 or later     |
 
 
 Other targets may work but are untested

--- a/README.md
+++ b/README.md
@@ -1,19 +1,37 @@
 # Lua for Open Watcom
 
-This repository contains wmake style makefiles and patches to build [Lua](https://lua.org) on Open Watcom 1.9 or later. 
-The primary goal is to allow Lua scripts to be run on DOS systems in real mode.
+This repository contains `wmake` style makefiles and patches to build [Lua](https://lua.org) on Open Watcom 1.9 or later. 
+The primary goal was to allow Lua scripts to be run on DOS systems in real mode but has expanded
+to include all Open Watcom targets that don't require external dependencies to build.
 
 ## Runtime Requirements
-To run Lua built by Open Watcom you will need the following:
 
-| Requirement                                                                                                                                                                                                  | Sources/Comment                                                                                                                                                                                                                                                         |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [8088 CPU](https://en.wikipedia.org/wiki/Intel_8088)*<br/> <pre>*or compatibiles<br/>like the 8086, V20,<br/>286, 386 etc<br/><br/>Machine emulators<br/>provided as an alternative<br/>for other ISAs</pre> | [86Box](https://86box.net/) ([GitHub](https://github.com/86Box/86Box))<br/>[DOSBox-X](https://dosbox-x.com/) ([GitHub](https://github.com/joncampbell123/dosbox-x))<br/>[PCem](https://www.pcem-emulator.co.uk/) ([GitHub](https://github.com/sarah-walker-pcem/pcem/)) |
-| PC-DOS 2.1 or higher                                                                                                                                                                                         | [FreeDOS](https://www.freedos.org/download/)<br/>[DOSBox-X](https://dosbox-x.com/) ([GitHub](https://github.com/joncampbell123/dosbox-x))<br/>[SvarDOS](http://svardos.org/)                                                                                            |
-| At least 320 kilobytes<br/>of total system memory                                                                                                                                                            | <pre>Any memory above<br/>640 kilobytes is<br/>inaccessible to all<br/>real mode DOS programs                                                                                                                                                                           |
-| At least 600 kilobytes<br/>of hard disk space or x2<br/>360 kilobyte diskettes                                                                                                                               | <pre>Can be ran directly<br/>from a diskette on<br/>machines without a<br/>hard drive                                                                                                                                                                                   |
+Lua for Watcom binaries can run on a number of legacy systems as well as some modern ones.
 
-> If in doubt, install [DOSBox-X](https://dosbox-x.com/)
+### Absolute Minimum Requirements
+
+These are the absolute lowest system requirements needed for a PC to run `LUA16.EXE`. 
+
+| Type                 | Requirement                                                 | Remarks                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|----------------------|-------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| CPU                  | [8086 compatible](https://en.wikipedia.org/wiki/Intel_8086) | <pre>Compatibles like<br/>the Intel 8088, NEC V20,<br/>286, 386 etc<br/><br/>Machine emulators<br/>provided as an alternative<br/>for other ISAs</pre>[86Box](https://86box.net/) ([GitHub](https://github.com/86Box/86Box))<br/>[DOSBox-X](https://dosbox-x.com/) ([GitHub](https://github.com/joncampbell123/dosbox-x))<br/>[PCem](https://www.pcem-emulator.co.uk/) ([GitHub](https://github.com/sarah-walker-pcem/pcem/)) |
+| Operating System     | PC-DOS 2.0                                                  | [FreeDOS](https://www.freedos.org/download/)<br/>[DOSBox-X](https://dosbox-x.com/) ([GitHub](https://github.com/joncampbell123/dosbox-x))<br/>[SvarDOS](http://svardos.org/)                                                                                                                                                                                                                                                  |
+| Random Access Memory | At least 512 kilobytes<br/>of base system memory            | <pre>Any memory above<br/>640 kilobytes is<br/>inaccessible to all<br/>real mode DOS programs                                                                                                                                                                                                                                                                                                                                 |
+| Storage              | At least 150 kilobytes<br/>of free disk space               | <pre>Can be ran directly<br/>from a diskette on<br/>machines without a<br/>hard drive                                                                                                                                                                                                                                                                                                                                         |
+
+### Binary Compatibility Matrix
+
+| Operating System                                                         | Minimum CPU ISA            | LUA16.EXE | LUA4G.EXE | LUANT.EXE |
+|--------------------------------------------------------------------------|----------------------------|-----------|-----------|-----------|
+| DOS 2.0+                                                                 | 8086                       | Yes       | No        | No        |
+| DOS 5.0+                                                                 | 8086<br>80386SX            | Yes       | No<br>Yes | No        |
+| Windows<br/>Windows 2<br/>Windows 3<br/>Windows 3.1                      | 8086                       | Yes       | No        | No        |
+| Windows 95                                                               | 80386SX                    | Yes       | Yes       | Yes       |
+| Windows 98                                                               | 80486SX+80487SX<br>80486DX | Yes       | Yes       | Yes       |
+| Windows 2000<br/>Windows ME                                              | 80586                      | No        | No        | Yes       |
+| Windows XP                                                               | 80586<br/>x86_64           | No        | No        | Yes       |
+| Windows Vista<br/>Windows 7<br/>Windows 8<br/>Windows 8.1<br/>Windows 10 | 80686<br/>x86_64           | No        | No        | Yes       |
+| Windows 11                                                               | x86_64                     | No        | No        | Yes       |
 
 ## Build Requirements
 To build Lua with Open Watcom you will need the following:
@@ -22,11 +40,11 @@ To build Lua with Open Watcom you will need the following:
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Lua 5.4 source code (or build machine with `git submodules`)                                                                                                                                                                           | [lua.org](https://lua.org/ftp/) ([GitHub](https://github.com/lua/lua/tree/v5.4.6))                                                                                                                                                                                                                                                                         |
 | Open Watcom 1.9 (or later)                                                                                                                                                                                                             | [openwatcom.org](https://www.openwatcom.org/) ([GitHub](https://github.com/open-watcom))<br/>[FreeDOS Bonus CD](https://www.freedos.org/download/) (`FDIMPLES`)<br/>[SvarDOS](http://svardos.org/?p=repo) (`PKGNET` repository)                                                                                                                            |
-| DOS operating system<br/>(MS-DOS 5.0 compatible)                                                                                                                                                                                       | [FreeDOS](https://www.freedos.org/download/)<br/>[DOSBox-X](https://dosbox-x.com/) ([GitHub](https://github.com/joncampbell123/dosbox-x))<br/>[SvarDOS](http://svardos.org/)                                                                                                                                                                               |
+| Operating System supported by Open Watcom<br/>(at least MS-DOS 5.0)                                                                                                                                                                    | [FreeDOS](https://www.freedos.org/download/)<br/>[DOSBox-X](https://dosbox-x.com/) ([GitHub](https://github.com/joncampbell123/dosbox-x))<br/>[SvarDOS](http://svardos.org/)                                                                                                                                                                               |
 | [80386 compatible processor](https://en.wikipedia.org/wiki/I386)* <br/> <pre>*Any AMD or Intel CPU <br/>made in the last 3 decades<br/>is compatible.<br/><br/>Machine emulators provided <br/>as an alternative for other ISAs </pre> | [86Box](https://86box.net/) ([GitHub](https://github.com/86Box/86Box))<br/>[DOSBox-X](https://dosbox-x.com/) ([GitHub](https://github.com/joncampbell123/dosbox-x))<br/>[PCem](https://www.pcem-emulator.co.uk/) ([GitHub](https://github.com/sarah-walker-pcem/pcem/))<br/>[Qemu](https://www.qemu.org/) ([GitLab](https://gitlab.com/qemu-project/qemu)) |
 | A patching utility                                                                                                                                                                                                                     | [GNU Patch](https://savannah.gnu.org/projects/patch/)<br>[DifPat](https://github.com/deverac/difpat)                                                                                                                                                                                                                                                       |
 
-> If in doubt, install [DOSBox-X](https://dosbox-x.com/)
+> If in doubt, [DOSBox-X](https://dosbox-x.com/) can be used on a modern machine
 
 ## How to build
 1) Extract Luas source code to the `Lua` folder. This can be achieved in two ways:
@@ -48,6 +66,7 @@ To build Lua with Open Watcom you will need the following:
    |-------------------------|----------------------|-------------|--------------------|
    | `wmake -f wm_dos16.mak` | `dist/bin/lua16.exe` | PC-DOS 2.0+ | 8086/8088 or later |
    | `wmake -f wm_dos4g.mak` | `dist/bin/lua4g.exe` | MS-DOS 5.0+ | 80386 or later     |
+   | `wmake -f wm_dosnt.mak` | `dist/bin/luant.exe` | Windows 95+ | 80386 or later     |
 
 
 Other targets may work but are untested

--- a/README.md
+++ b/README.md
@@ -19,19 +19,33 @@ These are the absolute lowest system requirements needed for a PC to run `LUA16.
 | Random Access Memory | At least 512 kilobytes<br/>of base system memory            | <pre>Any memory above<br/>640 kilobytes is<br/>inaccessible to all<br/>real mode DOS programs                                                                                                                                                                                                                                                                                                                                 |
 | Storage              | At least 150 kilobytes<br/>of free disk space               | <pre>Can be ran directly<br/>from a diskette on<br/>machines without a<br/>hard drive                                                                                                                                                                                                                                                                                                                                         |
 
+### Binary Native Targets
+
+Since Open Watcom can produce binaries for several operating systems, 
+each binary has been given a unique name to distinguish the native **Operating System** (OS) 
+and **Instruction Set Architecture** (ISA) it is intended for.  
+
+| Binary Name   | Native OS       | Native ISA |
+|---------------|-----------------|------------|
+| **LUA16.EXE** | Real mode DOS   | 8086       |
+| **LUA4G.EXE** | DOS4GW extender | 80386      |
+| **LUANT.EXE** | Windows 95      | 80386      |
+
 ### Binary Compatibility Matrix
 
-| Operating System                                                         | Minimum CPU ISA            | LUA16.EXE | LUA4G.EXE | LUANT.EXE |
-|--------------------------------------------------------------------------|----------------------------|-----------|-----------|-----------|
-| DOS 2.0+                                                                 | 8086                       | Yes       | No        | No        |
-| DOS 5.0+                                                                 | 8086<br>80386SX            | Yes       | No<br>Yes | No        |
-| Windows<br/>Windows 2<br/>Windows 3<br/>Windows 3.1                      | 8086                       | Yes       | No        | No        |
-| Windows 95                                                               | 80386SX                    | Yes       | Yes       | Yes       |
-| Windows 98                                                               | 80486SX+80487SX<br>80486DX | Yes       | Yes       | Yes       |
-| Windows 2000<br/>Windows ME                                              | 80586                      | No        | No        | Yes       |
-| Windows XP                                                               | 80586<br/>x86_64           | No        | No        | Yes       |
-| Windows Vista<br/>Windows 7<br/>Windows 8<br/>Windows 8.1<br/>Windows 10 | 80686<br/>x86_64           | No        | No        | Yes       |
-| Windows 11                                                               | x86_64                     | No        | No        | Yes       |
+Some Operating Systems can run binaries intended for another out of the box. 
+Do keep in mind, however, that in most of these cases the Operating System is newer and has higher minimum requirements.
+
+| Operating System                            | Minimum CPU ISA            | LUA16.EXE | LUA4G.EXE | LUANT.EXE |
+|---------------------------------------------|----------------------------|-----------|-----------|-----------|
+| DOS 2.x - 4.x<br/>Windows 1.x - Windows 3.x | 8086                       | Yes       | No        | No        |
+| DOS 5.x - 7.x                               | 8086<br>80386SX            | Yes       | No<br>Yes | No        |
+| Windows 95                                  | 80386SX                    | Yes       | Yes       | Yes       |
+| Windows 98                                  | 80486SX+80487SX<br>80486DX | Yes       | Yes       | Yes       |
+| Windows 2000 - ME                           | 80586                      | No        | No        | Yes       |
+| Windows XP                                  | 80586<br/>x86_64           | No        | No        | Yes       |
+| Windows Vista - 10                          | 80686<br/>x86_64           | No        | No        | Yes       |
+| Windows 11                                  | x86_64                     | No        | No        | Yes       |
 
 ## Build Requirements
 To build Lua with Open Watcom you will need the following:

--- a/wm_os216.mak
+++ b/wm_os216.mak
@@ -1,0 +1,75 @@
+# Watcom Makefile for building Lua 5.4.6
+# This is the DOS 4G flat model version
+# There are no configurable parts to this file
+# Run with `wmake -f wm_os216.mak`
+
+objs =  $(OBJDIR)lapi.obj      $(OBJDIR)lctype.obj    &
+        $(OBJDIR)lfunc.obj     $(OBJDIR)lmathlib.obj  &
+        $(OBJDIR)loslib.obj    $(OBJDIR)ltable.obj    &
+        $(OBJDIR)lundump.obj   $(OBJDIR)lauxlib.obj   &
+        $(OBJDIR)ldblib.obj    $(OBJDIR)lgc.obj       &
+        $(OBJDIR)lmem.obj      $(OBJDIR)lparser.obj   &
+        $(OBJDIR)ltablib.obj   $(OBJDIR)lutf8lib.obj  &
+        $(OBJDIR)lbaselib.obj  $(OBJDIR)ldebug.obj    &
+        $(OBJDIR)linit.obj     $(OBJDIR)loadlib.obj   &
+        $(OBJDIR)lstate.obj    $(OBJDIR)ltm.obj       &
+        $(OBJDIR)lvm.obj       $(OBJDIR)lcode.obj     &
+        $(OBJDIR)ldo.obj       $(OBJDIR)liolib.obj    &
+        $(OBJDIR)lobject.obj   $(OBJDIR)lstring.obj   &
+        $(OBJDIR)lzio.obj      $(OBJDIR)lcorolib.obj  &
+        $(OBJDIR)ldump.obj     $(OBJDIR)llex.obj      &
+        $(OBJDIR)lopcodes.obj  $(OBJDIR)lstrlib.obj
+
+lua_obj = $(OBJDIR)lua.obj
+luac_obj = $(OBJDIR)luac.obj
+
+CC = *wcc
+
+CFLAGS = -q -bt=os2 -bc -2 -ml -d0 -osr -zc
+LFLAGS = SYS os2 OPT st=8192
+
+!ifdef __UNIX__
+BINDIR = dist/bin/
+OBJDIR = obj/21/
+SRCDIR = lua/
+!else
+BINDIR = dist\bin\ #
+OBJDIR = obj\21\ #
+SRCDIR = lua\ #
+!endif
+
+$(BINDIR)lua21.exe: $(OBJDIR) $(BINDIR) $(objs) $(lua_obj)
+    *wlink NAME $@ $(LFLAGS) FILE {$(objs) $(lua_obj)}
+
+$(BINDIR)luac21.exe: $(BINDIR) $(OBJDIR) $(objs) $(luac_obj)
+    *wlink NAME $@ $(LFLAGS) FILE {$(objs) $(luac_obj)}
+
+{$(SRCDIR)}.c{$(OBJDIR)}.obj:
+    $(CC) $(CFLAGS) -fo=$@ $<
+
+clean: .SYMBOLIC
+!ifdef __UNIX__
+    @!if [ -e $(OBJDIR) ]; then rm -R $(OBJDIR); fi
+    @!if [ -e $(BINDIR)luant.exe ]; then rm $(BINDIR)luant.exe; fi
+    @!if [ -e $(BINDIR)luacnt.exe ]; then rm $(BINDIR)luacnt.exe; fi
+!else
+    !ifdef __NT__
+         @!if exist $(OBJDIR) rd /S /Q $(OBJDIR)
+    !else
+         @!if exist $(OBJDIR) deltree /Y $(OBJDIR)
+    !endif
+    @!if exist $(BINDIR)luant.exe del $(BINDIR)luant.exe
+    @!if exist $(BINDIR)luacnt.exe del $(BINDIR)luacnt.exe
+!endif
+
+dist:
+    mkdir dist
+
+obj:
+    mkdir obj
+
+$(BINDIR): dist
+    mkdir $(BINDIR)
+
+$(OBJDIR): obj
+    mkdir $(OBJDIR)

--- a/wm_os232.mak
+++ b/wm_os232.mak
@@ -1,0 +1,75 @@
+# Watcom Makefile for building Lua 5.4.6
+# This is the DOS 4G flat model version
+# There are no configurable parts to this file
+# Run with `wmake -f wm_os232.mak`
+
+objs =  $(OBJDIR)lapi.obj      $(OBJDIR)lctype.obj    &
+        $(OBJDIR)lfunc.obj     $(OBJDIR)lmathlib.obj  &
+        $(OBJDIR)loslib.obj    $(OBJDIR)ltable.obj    &
+        $(OBJDIR)lundump.obj   $(OBJDIR)lauxlib.obj   &
+        $(OBJDIR)ldblib.obj    $(OBJDIR)lgc.obj       &
+        $(OBJDIR)lmem.obj      $(OBJDIR)lparser.obj   &
+        $(OBJDIR)ltablib.obj   $(OBJDIR)lutf8lib.obj  &
+        $(OBJDIR)lbaselib.obj  $(OBJDIR)ldebug.obj    &
+        $(OBJDIR)linit.obj     $(OBJDIR)loadlib.obj   &
+        $(OBJDIR)lstate.obj    $(OBJDIR)ltm.obj       &
+        $(OBJDIR)lvm.obj       $(OBJDIR)lcode.obj     &
+        $(OBJDIR)ldo.obj       $(OBJDIR)liolib.obj    &
+        $(OBJDIR)lobject.obj   $(OBJDIR)lstring.obj   &
+        $(OBJDIR)lzio.obj      $(OBJDIR)lcorolib.obj  &
+        $(OBJDIR)ldump.obj     $(OBJDIR)llex.obj      &
+        $(OBJDIR)lopcodes.obj  $(OBJDIR)lstrlib.obj
+
+lua_obj = $(OBJDIR)lua.obj
+luac_obj = $(OBJDIR)luac.obj
+
+CC = *wcc386
+
+CFLAGS = -q -bt=os2 -bc -3 -d0 -osr -zc
+LFLAGS = SYS os2v2 OPT st=8192
+
+!ifdef __UNIX__
+BINDIR = dist/bin/
+OBJDIR = obj/22/
+SRCDIR = lua/
+!else
+BINDIR = dist\bin\ #
+OBJDIR = obj\22\ #
+SRCDIR = lua\ #
+!endif
+
+$(BINDIR)lua22.exe: $(OBJDIR) $(BINDIR) $(objs) $(lua_obj)
+    *wlink NAME $@ $(LFLAGS) FILE {$(objs) $(lua_obj)}
+
+$(BINDIR)luac22.exe: $(BINDIR) $(OBJDIR) $(objs) $(luac_obj)
+    *wlink NAME $@ $(LFLAGS) FILE {$(objs) $(luac_obj)}
+
+{$(SRCDIR)}.c{$(OBJDIR)}.obj:
+    $(CC) $(CFLAGS) -fo=$@ $<
+
+clean: .SYMBOLIC
+!ifdef __UNIX__
+    @!if [ -e $(OBJDIR) ]; then rm -R $(OBJDIR); fi
+    @!if [ -e $(BINDIR)luant.exe ]; then rm $(BINDIR)luant.exe; fi
+    @!if [ -e $(BINDIR)luacnt.exe ]; then rm $(BINDIR)luacnt.exe; fi
+!else
+    !ifdef __NT__
+         @!if exist $(OBJDIR) rd /S /Q $(OBJDIR)
+    !else
+         @!if exist $(OBJDIR) deltree /Y $(OBJDIR)
+    !endif
+    @!if exist $(BINDIR)luant.exe del $(BINDIR)luant.exe
+    @!if exist $(BINDIR)luacnt.exe del $(BINDIR)luacnt.exe
+!endif
+
+dist:
+    mkdir dist
+
+obj:
+    mkdir obj
+
+$(BINDIR): dist
+    mkdir $(BINDIR)
+
+$(OBJDIR): obj
+    mkdir $(OBJDIR)


### PR DESCRIPTION
Added `lua21.exe` and `lua22.exe` for running Lua on OS/2 16-bit and 32-bit respectively.